### PR TITLE
Fix course dashboard timer and layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,8 @@
                     <h2 id="courseName">Course Dashboard</h2>
                 </div>
                 <div class="course-timer">
-                    <div class="timer-display" id="timerDisplay">00:00:00</div>
+                    <input type="text" class="timer-display" id="timerDisplay" value="25:00">
                     <div class="timer-controls">
-                        <input type="number" class="timer-input" id="timerMinutes" placeholder="Minutes" min="1" max="300">
                         <button class="timer-btn start-btn" onclick="startTimer()">Start</button>
                         <button class="timer-btn pause-btn" onclick="pauseTimer()">Pause</button>
                         <button class="timer-btn reset-btn" onclick="resetTimer()">Reset</button>
@@ -638,8 +637,8 @@ function showCourseDashboard(courseName) {
     document.getElementById('unitView').style.display = 'none';
     document.getElementById('courseName').textContent = courseName;
     document.getElementById("courseDashboard").classList.remove("hidden");
-  document.getElementById("mainContent").classList.add("hidden"); // optional if you're hiding schedule
-      document.getElementById("unitView").classList.remove("hidden");
+    document.getElementById("mainContent").classList.add("hidden");
+    document.getElementById("unitView").classList.add("hidden");
 
     
     updateUnitsDisplay();
@@ -662,10 +661,43 @@ function showCourseDashboard(courseName) {
         }
 
         // Timer functions
-        function startTimer() {
-            const minutes = parseInt(document.getElementById('timerMinutes').value) || 25;
+        function parseTimerInput() {
+            const val = document.getElementById('timerDisplay').value.trim();
+            const parts = val.split(':').map(n => parseInt(n, 10));
+            let total = 0;
+            if (parts.length === 3) {
+                total = parts[0] * 3600 + parts[1] * 60 + parts[2];
+            } else if (parts.length === 2) {
+                total = parts[0] * 60 + parts[1];
+            } else if (parts.length === 1 && !isNaN(parts[0])) {
+                total = parts[0] * 60;
+            } else {
+                total = 1500; // default 25:00
+            }
+            return { minutes: Math.floor(total / 60), seconds: total % 60 };
+        }
+
+        function formatTimerDisplay() {
             if (!courseTimer) {
-                courseTimer = { minutes: minutes, seconds: 0, isRunning: false };
+                return '00:00';
+            }
+            const totalSec = courseTimer.minutes * 60 + courseTimer.seconds;
+            const hrs = Math.floor(totalSec / 3600);
+            const mins = Math.floor((totalSec % 3600) / 60);
+            const secs = totalSec % 60;
+            if (hrs > 0) {
+                return `${hrs.toString().padStart(2,'0')}:${mins.toString().padStart(2,'0')}:${secs.toString().padStart(2,'0')}`;
+            }
+            return `${mins.toString().padStart(2,'0')}:${secs.toString().padStart(2,'0')}`;
+        }
+
+        function startTimer() {
+            const {minutes, seconds} = parseTimerInput();
+            if (!courseTimer) {
+                courseTimer = { minutes: minutes, seconds: seconds, isRunning: false };
+            } else {
+                courseTimer.minutes = minutes;
+                courseTimer.seconds = seconds;
             }
             
             if (!courseTimer.isRunning) {
@@ -682,8 +714,8 @@ function showCourseDashboard(courseName) {
         }
 
         function resetTimer() {
-            const minutes = parseInt(document.getElementById('timerMinutes').value) || 25;
-            courseTimer = { minutes: minutes, seconds: 0, isRunning: false };
+            const {minutes, seconds} = parseTimerInput();
+            courseTimer = { minutes: minutes, seconds: seconds, isRunning: false };
             clearInterval(timerInterval);
             updateTimerDisplay();
         }
@@ -707,17 +739,7 @@ function showCourseDashboard(courseName) {
         }
 
         function updateTimerDisplay() {
-            if (!courseTimer) {
-                document.getElementById('timerDisplay').textContent = '00:00:00';
-                return;
-            }
-            
-            const hours = Math.floor(courseTimer.minutes / 60);
-            const mins = courseTimer.minutes % 60;
-            const secs = courseTimer.seconds;
-            
-            document.getElementById('timerDisplay').textContent = 
-                `${hours.toString().padStart(2, '0')}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+            document.getElementById('timerDisplay').value = formatTimerDisplay();
         }
 
         // Data export/import
@@ -1130,13 +1152,21 @@ function updateUnitsDisplay() {
   const stored = localStorage.getItem('appData');
   if (stored) {
     appData = JSON.parse(stored);
+    // migrate old unit format
+    Object.values(appData.courses).forEach(course => {
+      Object.keys(course.units).forEach(u => {
+        if (!course.units[u] || !course.units[u].notes) {
+          course.units[u] = { notes: {} };
+        }
+      });
+    });
   } else {
     appData = {
       courses: {
         'Example Course': {
           units: {
-            'Unit 1': [],
-            'Unit 2': []
+            'Unit 1': { notes: {} },
+            'Unit 2': { notes: {} }
           },
           notepad: ''
         }

--- a/style.css
+++ b/style.css
@@ -54,6 +54,30 @@ body {
     transition: background 0.3s ease;
 }
 
+.dashboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.course-timer {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+}
+
+.timer-display {
+    width: 100px;
+    text-align: center;
+    font-size: 1.5em;
+    padding: 5px;
+    border: 1px solid #555;
+    border-radius: 6px;
+    background: #1e1e1e;
+    color: #e0e0e0;
+}
+
 .schedule-header {
   display: flex;
   justify-content: space-between; /* left and right alignment */
@@ -248,6 +272,12 @@ tr.highlight-period td {
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     gap: 20px;
     margin-bottom: 30px;
+}
+
+.notes-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px;
 }
 
 .unit-card,


### PR DESCRIPTION
## Summary
- clean up course dashboard display
- update timer to accept input directly in the display
- align course timer to the right side of header
- correct Example Course default units and migrate old data
- show two note sections per row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e8041b20c8333a7e113173ddbd762