### PR TITLE
Fix schedule default load

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,19 @@ Just type naturally!"></textarea>
         let currentNoteSection = null;
         let currentSubsection = null;
 
+        const defaultPeriods = [
+            { name: 'Wake up', time: '7:30-8:00' },
+            { name: 'P1', time: '8:00-9:45' },
+            { name: 'P2', time: '10:00-11:45' },
+            { name: 'Lunch', time: '12:00-1:00' },
+            { name: 'P3', time: '1:00-2:45' },
+            { name: 'P4', time: '3:00-4:45' },
+            { name: 'Dinner', time: '5:00-6:00' },
+            { name: 'P5', time: '6:00-7:45' },
+            { name: 'P6', time: '8:00-9:45' },
+            { name: 'Sleep', time: '10:00-10:30' }
+        ];
+
         // Initialize app
         function initApp() {
             loadData();
@@ -296,18 +309,6 @@ Just type naturally!"></textarea>
 
         // Schedule management Note: May need fixing
         function initializeSchedule() {
-            const defaultPeriods = [
-                { name: 'Wake up', time: '7:30-8:00' },
-                { name: 'P1', time: '8:00-9:45' },
-                { name: 'P2', time: '10:00-11:45' },
-                { name: 'Lunch', time: '12:00-1:00' },
-                { name: 'P3', time: '1:00-2:45' },
-                { name: 'P4', time: '3:00-4:45' },
-                { name: 'Dinner', time: '5:00-6:00' },
-                { name: 'P5', time: '6:00-7:45' },
-                { name: 'P6', time: '8:00-9:45' },
-                { name: 'Sleep', time: '10:00-10:30' }
-            ];
 
             const weekKey = getWeekKey();
             if (!appData.schedule[weekKey]) {
@@ -1189,15 +1190,13 @@ function updateUnitsDisplay() {
     };
   }
 
-  // Ensure current week has a default schedule NOTE OK THIS IS IT i believe this is already defined so it conflicts
-  //const currentWeekKey = getWeekKey();
-  //if (!appData.schedule[currentWeekKey]) {
-   // appData.schedule[currentWeekKey] = {
-   //   "Period 1": ["", "", "", "", "", "", ""],
-   //   "Period 2": ["", "", "", "", "", "", ""],
-   //   "Period 3": ["", "", "", "", "", "", ""]
-  //  };
- // }
+  const weekKey = getWeekKey();
+  if (!appData.schedule[weekKey]) {
+    appData.schedule[weekKey] = {};
+    defaultPeriods.forEach(p => {
+      appData.schedule[weekKey][p.name] = { time: p.time, days: ['', '', '', '', '', '', ''] };
+    });
+  }
 
   updateCourseButtons();
   updateScheduleDisplay();


### PR DESCRIPTION
## Summary
- show default periods by defining them globally
- initialize the current week's schedule when loading data
- simplify `initializeSchedule` to use the global defaults

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e903229f88333b2d59485eba62efc