### PR TITLE
Add undo/redo for schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,10 +42,14 @@
             <!-- Schedule section -->
             <div class="schedule-section">
                 <div class="schedule-header">
-                    <h2 id="weekTitle">Week of</h2>
                     <div class="week-nav">
                         <button class="nav-btn" onclick="previousWeek()">← Previous</button>
+                        <h2 id="weekTitle"></h2>
                         <button class="nav-btn" onclick="nextWeek()">Next →</button>
+                    </div>
+                    <div class="history-nav">
+                        <button class="nav-btn" id="undoActionBtn" onclick="undoSchedule()">Undo</button>
+                        <button class="nav-btn" id="redoActionBtn" onclick="redoSchedule()">Redo</button>
                     </div>
                 </div>
                 <table class="schedule-table"> <!-- Note: may need fixing -->
@@ -207,6 +211,10 @@ Just type naturally!"></textarea>
             { name: 'Sleep', time: '10:00-10:30' }
         ];
 
+        // --- History for undo/redo ---
+        let scheduleHistory = [];
+        let historyIndex = -1;
+
         // Initialize app
         function initApp() {
             loadData();
@@ -317,9 +325,10 @@ Just type naturally!"></textarea>
                     appData.schedule[weekKey][p.name] = { time: p.time, days: ['', '', '', '', '', '', ''] };
                 });
             }
-            
+
             updateScheduleDisplay();
             updateWeekTitle();
+            initScheduleHistory();
         }
 
         function getWeekKey() {
@@ -340,10 +349,57 @@ Just type naturally!"></textarea>
             const today = new Date();
             const weekStart = new Date(today);
             weekStart.setDate(today.getDate() - today.getDay() + (currentWeekOffset * 7));
-            
-            const options = { month: 'long', day: 'numeric', year: 'numeric' };
-            document.getElementById('weekTitle').textContent = 
-                `Week of ${weekStart.toLocaleDateString('en-US', options)}`;
+            const weekEnd = new Date(weekStart);
+            weekEnd.setDate(weekStart.getDate() + 6);
+
+            const options = { month: 'numeric', day: 'numeric' };
+            document.getElementById('weekTitle').textContent =
+                `${weekStart.toLocaleDateString('en-US', options)}-${weekEnd.toLocaleDateString('en-US', options)}`;
+        }
+
+        // ----- History Helpers -----
+        function initScheduleHistory() {
+            const weekKey = getWeekKey();
+            scheduleHistory = [JSON.parse(JSON.stringify(appData.schedule[weekKey] || {}))];
+            historyIndex = 0;
+            updateUndoRedoButtons();
+        }
+
+        function pushScheduleState() {
+            const weekKey = getWeekKey();
+            scheduleHistory = scheduleHistory.slice(0, historyIndex + 1);
+            scheduleHistory.push(JSON.parse(JSON.stringify(appData.schedule[weekKey] || {})));
+            historyIndex++;
+            updateUndoRedoButtons();
+        }
+
+        function undoSchedule() {
+            if (historyIndex > 0) {
+                historyIndex--;
+                const weekKey = getWeekKey();
+                appData.schedule[weekKey] = JSON.parse(JSON.stringify(scheduleHistory[historyIndex]));
+                updateScheduleDisplay();
+                saveData();
+                updateUndoRedoButtons();
+            }
+        }
+
+        function redoSchedule() {
+            if (historyIndex < scheduleHistory.length - 1) {
+                historyIndex++;
+                const weekKey = getWeekKey();
+                appData.schedule[weekKey] = JSON.parse(JSON.stringify(scheduleHistory[historyIndex]));
+                updateScheduleDisplay();
+                saveData();
+                updateUndoRedoButtons();
+            }
+        }
+
+        function updateUndoRedoButtons() {
+            const undoBtn = document.getElementById('undoActionBtn');
+            const redoBtn = document.getElementById('redoActionBtn');
+            if (undoBtn) undoBtn.disabled = historyIndex <= 0;
+            if (redoBtn) redoBtn.disabled = historyIndex >= scheduleHistory.length - 1;
         }
 
      function updateScheduleDisplay() {
@@ -397,6 +453,7 @@ Just type naturally!"></textarea>
             saveData();
             updateScheduleDisplay();
             updateClock();
+            pushScheduleState();
         }
     }
 });
@@ -411,6 +468,7 @@ Just type naturally!"></textarea>
             scheduleData[period].time = timeCell.textContent.trim();
             saveData();
             updateCurrentActivity();
+            pushScheduleState();
         });
         row.appendChild(timeCell);
         
@@ -424,8 +482,10 @@ Just type naturally!"></textarea>
             cell.textContent = days[dayOrder[i]] || '';
             cell.addEventListener('blur', () => {
                 scheduleData[period].days[dayOrder[i]] = cell.textContent;
-                saveData(); 
+                saveData();
                       updateCurrentActivity();
+
+            pushScheduleState();
 
 });
 
@@ -479,6 +539,7 @@ Just type naturally!"></textarea>
                 appData.schedule[weekKey] = Object.fromEntries(reordered);
                 saveData();
                 updateScheduleDisplay();
+                pushScheduleState();
             }
         });
 
@@ -493,11 +554,12 @@ Just type naturally!"></textarea>
             if (!appData.schedule[weekKey]) {
                 appData.schedule[weekKey] = {};
             }
-            
+
             const newPeriod = `New Period ${Object.keys(appData.schedule[weekKey]).length + 1}`;
             appData.schedule[weekKey][newPeriod] = { time: '', days: ['', '', '', '', '', '', ''] };
             updateScheduleDisplay();
             saveData();
+            pushScheduleState();
         }
 
         function previousWeek() {
@@ -1045,14 +1107,16 @@ function deleteScheduleRow(periodName) {
             weekKey: weekKey,
             data: appData.schedule[weekKey][periodName]
         };
-        delete appData.schedule[weekKey][periodName];
-        updateScheduleDisplay();
-        saveData();
-        showUndoButton('Schedule row', () => {
-            appData.schedule[lastDeleted.weekKey][lastDeleted.name] = lastDeleted.data;
-            updateScheduleDisplay();
-            saveData();
-        });
+         delete appData.schedule[weekKey][periodName];
+         updateScheduleDisplay();
+         saveData();
+        pushScheduleState();
+         showUndoButton('Schedule row', () => {
+             appData.schedule[lastDeleted.weekKey][lastDeleted.name] = lastDeleted.data;
+             updateScheduleDisplay();
+             saveData();
+            pushScheduleState();
+         });
     }
 }
 

--- a/style.css
+++ b/style.css
@@ -81,17 +81,23 @@ body {
 .schedule-header {
   display: flex;
   justify-content: space-between; /* left and right alignment */
-  align-items: flex-start;        /* 🔼 top-align */
+  align-items: center;
   flex-wrap: wrap;
 }
 
 
- .week-nav {
+.week-nav {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+        .history-nav {
             display: flex;
             gap: 10px;
             justify-content: flex-end;
             margin-left: 20px;
-            align-items: flex-start;
+            align-items: center;
         }
 
         .nav-btn {
@@ -100,6 +106,11 @@ body {
             padding: 8px 16px;
             border-radius: 6px;
             cursor: pointer;
+        }
+
+        .nav-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
         }
 
 .course-btn:hover,


### PR DESCRIPTION
## Summary
- enable undo/redo history for schedule modifications
- add Undo and Redo buttons to schedule header
- center week range between prev/next buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68510cee878483339c2a6435543ca26e